### PR TITLE
Refactor sendMessage function to use 'email' parameter instead of 'txEmail'

### DIFF
--- a/Backend/modules/db_actions_dispatcher/db_actions_dispatcher.bal
+++ b/Backend/modules/db_actions_dispatcher/db_actions_dispatcher.bal
@@ -109,9 +109,9 @@ public isolated function getUser(string email) returns Types:User? {
     return DB:findOne("users", email, {});
 }
 
-public isolated function sendMessage(string txEmail, Types:Message message) returns boolean {
+public isolated function sendMessage(string email, Types:Message message) returns boolean {
     do {
-        boolean insertResult = DB:insert("messages", txEmail, message);
+        boolean insertResult = DB:insert("messages", email, message);
         return insertResult;
 
     } on fail var e {

--- a/Frontend/app/(auth)/sign-in/page.jsx
+++ b/Frontend/app/(auth)/sign-in/page.jsx
@@ -3,29 +3,29 @@ import { handleServerLogin } from '@/server';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import LoadingScreen from '/components/LoadingScreen';  // Import the LoadingScreen component
+import LoadingScreen from '/components/LoadingScreen';  
 
 export default function Home() {
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false); // Add state to control loading screen
+  const [isLoading, setIsLoading] = useState(false); 
 
   const handleSignup = () => {
     router.push('/sign-up');
   };
 
   const handleLogin = () => {
-    // Show the loading screen during login processing
+    
     setIsLoading(true);
 
     handleServerLogin({ username: "Admin", email: "ladmin@localhost", password: "admin" })
       .then(res => {
         if (res.user) {
-          // Simulate some delay before navigating to the chat list
+          
           setTimeout(() => {
-            router.push('/chat'); // Navigate to chat list after successful login
-          }, 2000); // Adjust delay if needed
+            router.push('/chat'); 
+          }, 2000); 
         } else {
-          setIsLoading(false); // Hide the loading screen if login fails
+          setIsLoading(false); 
           if (res.code === 403) {
             router.push('/');
           } else {
@@ -34,12 +34,12 @@ export default function Home() {
         }
       })
       .catch(() => {
-        setIsLoading(false); // Hide loading screen on error
+        setIsLoading(false); 
         alert('Login failed. Please try again.');
       });
   };
 
-  // Show LoadingScreen when isLoading is true
+  
   if (isLoading) {
     return <LoadingScreen />;
   }

--- a/Frontend/server/index.js
+++ b/Frontend/server/index.js
@@ -29,11 +29,12 @@ export class WebSocketClient {
 		}, 5000)
 	}
 
-	sendMessage(messageType, message) {
+	sendMessage(messageType, message, rxEmail) {
 		const data = {
 			messageType: messageType !== undefined ? messageType : "usermessage",
 			messageId: Date.now(),
 			message: message,
+			rxEmail: rxEmail,
 			...serverLoginDetails
 		}
 		


### PR DESCRIPTION
This pull request refactors the `sendMessage` function to use the `email` parameter instead of the `txEmail` parameter. This change ensures consistency in the function's parameter naming and improves code readability.